### PR TITLE
feat(main): two options for extra alias tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,16 @@ The `npm`-based commands *don't* need [grunt-cli](https://github.com/gruntjs/gru
 
 ## lintlovin.initConfig(grunt[, config] [, options])
 
-To be run from the parent project's Gruntfile.js to initialize Grunt with a basic config by sending the `grunt` object into it and extra configurations apart from the ones Lintlovin defines. One can also optionally specify some options:
+To be run from the parent project's Gruntfile.js. Initializes the `grunt` object sent in with a basic task setup. Also allows additional task setups to be sent in through `config` and for altering the basic setup in some ways through `options`.
+
+### Options
 
 * **integrationWatch** – makes the `watch` task also run tests in `test/integration/`, which can be unfeasable in big projects, but nice in smaller ones. Defaults to `false`.
 * **jsFiles** – an array of additional files to watch and lint. By default `.js`-files in top folder or below the `bin/`, `cli/`, `lib/` or `test/` folders will be watched and linted. (Also any non-js file in `test/` will be watched and will thus retrigger a test when changed)
 * **spaceFiles** – an array of additional files to just watch and whitespace lint.
 * **watchFiles** – an array of additional files to just watch.
+* **extraTestTasks** – an array of additional tasks to add to the `test` task alias
+* **extraTestAllTasks** – an array of additional tasks to add to the `test-all` task alias
 * **noMocha** – disables the [Mocha](http://visionmedia.github.io/mocha/) tests. Mocha tests are otherwise run if a `test/`-folder is found in the parent project.
 
 ## Changelog

--- a/index.js
+++ b/index.js
@@ -76,10 +76,15 @@ exports.initConfig = function (grunt, config, options) {
   ];
 
   var testTasks = ['lintspaces', 'jshint', 'setTestEnv'];
+  var integrationTestTasks = options.noIntegration ? ['test'] : ['test', 'mocha_istanbul:integration'];
+
   if (!options.noMocha) {
     plugins.push('grunt-mocha-istanbul');
     testTasks.push('mocha_istanbul:basic');
   }
+
+  testTasks = testTasks.concat(options.extraTestTasks || []);
+  integrationTestTasks = integrationTestTasks.concat(options.extraTestAllTasks || []);
 
   // Uhm, HACK! But WTF Grunt!
   var cwd = process.cwd();
@@ -96,6 +101,6 @@ exports.initConfig = function (grunt, config, options) {
   });
 
   grunt.registerTask('test', testTasks);
-  grunt.registerTask('test-all', options.noIntegration ? 'test' : ['test', 'mocha_istanbul:integration']);
+  grunt.registerTask('test-all', integrationTestTasks);
   grunt.registerTask('default', 'test');
 };


### PR DESCRIPTION
With `options.extraTestTasks` and `options.extraTestAllTasks` one can now easily ensure that more than the basic tasks are run as part of the ordinary tests or the integration tests.
