### PR TITLE
Check for missing and extra dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,5 +5,7 @@
 var lintlovin = require('./');
 
 module.exports = function (grunt) {
-  lintlovin.initConfig(grunt);
+  lintlovin.initConfig(grunt, {}, {
+    dependencyFiles: ['!bin/Gruntfile.default.js'],
+  });
 };

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ To be run from the parent project's Gruntfile.js. Initializes the `grunt` object
 * **integrationWatch** – makes the `watch` task also run tests in `test/integration/`, which can be unfeasable in big projects, but nice in smaller ones. Defaults to `false`.
 * **jsFiles** – an array of additional files to watch and lint. By default `.js`-files in top folder or below the `bin/`, `cli/`, `lib/` or `test/` folders will be watched and linted. (Also any non-js file in `test/` will be watched and will thus retrigger a test when changed)
 * **spaceFiles** – an array of additional files to just watch and whitespace lint.
+* **dependencyFiles** – an array of additional files to just check for dependencies.
 * **watchFiles** – an array of additional files to just watch.
 * **extraTestTasks** – an array of additional tasks to add to the `test` task alias
 * **extraTestAllTasks** – an array of additional tasks to add to the `test-all` task alias

--- a/index.js
+++ b/index.js
@@ -52,6 +52,13 @@ exports.initConfig = function (grunt, config, options) {
     }
   };
 
+  defaults['dependency-check'] = {
+    files: _.union(['<%= jshint.files %>'], options.dependencyFiles || []),
+    options: {
+      excludeMissingDev: true,
+    }
+  };
+
   if (!options.noMocha) {
     defaults.mocha_istanbul = {
       options: {

--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ exports.initConfig = function (grunt, config, options) {
         'lib/**/*.js',
         'test/**/*.js',
         'bin/**/*.js',
-        'cli/**/*.js'
+        'cli/**/*.js',
+        'tasks/**/*.js',
       ], options.jsFiles || []),
       options: { jshintrc: '.jshintrc' }
     },
@@ -75,7 +76,7 @@ exports.initConfig = function (grunt, config, options) {
     'grunt-contrib-watch'
   ];
 
-  var testTasks = ['lintspaces', 'jshint', 'setTestEnv'];
+  var testTasks = ['lintspaces', 'jshint', 'dependency-check', 'setTestEnv'];
   var integrationTestTasks = options.noIntegration ? ['test'] : ['test', 'mocha_istanbul:integration'];
 
   if (!options.noMocha) {
@@ -95,6 +96,8 @@ exports.initConfig = function (grunt, config, options) {
     grunt.loadNpmTasks(name);
   });
   process.chdir(cwd);
+
+  grunt.loadTasks('tasks');
 
   grunt.registerTask('setTestEnv', 'Ensure that environment (database etc) is set up for testing', function () {
     process.env.NODE_ENV = 'test';

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/bloglovin/lintlovin",
   "dependencies": {
+    "dependency-check": "^2.0.0",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-lintspaces": "~0.6.0",

--- a/tasks/dependency-check.js
+++ b/tasks/dependency-check.js
@@ -11,6 +11,7 @@ module.exports = function (grunt) {
     var options = this.options({
       missing: true,
       unused: true,
+      excludeMissingDev: false,
       package: '.',
     });
 
@@ -24,7 +25,7 @@ module.exports = function (grunt) {
       var results;
 
       if (options.unused) {
-        results = check.extra(pkg, deps);
+        results = check.extra(pkg, deps, { excludeDev: options.excludeMissingDev });
         if (results.length !== 0) {
           grunt.log.error('Modules in package.json not used in code: ' + grunt.log.wordlist(results, { color: 'red' }));
         }

--- a/tasks/dependency-check.js
+++ b/tasks/dependency-check.js
@@ -1,0 +1,43 @@
+/*jslint node: true */
+'use strict';
+
+module.exports = function (grunt) {
+  var check = require('dependency-check');
+
+  grunt.registerMultiTask('dependency-check', 'Matches used modules to listed dependencies', function () {
+    var done = this.async();
+
+    // Merge task-specific and/or target-specific options with these defaults.
+    var options = this.options({
+      missing: true,
+      unused: true,
+      package: '.',
+    });
+
+    check({ path: options.package, entries: this.filesSrc }, function(err, data) {
+      if (err) {
+        return grunt.fail.fatal(err);
+      }
+
+      var pkg = data.package;
+      var deps = data.used;
+      var results;
+
+      if (options.unused) {
+        results = check.extra(pkg, deps);
+        if (results.length !== 0) {
+          grunt.log.error('Modules in package.json not used in code: ' + grunt.log.wordlist(results, { color: 'red' }));
+        }
+      }
+
+      if (options.missing) {
+        results = check.missing(pkg, deps);
+        if (results.length !== 0) {
+          grunt.fail.fatal('Dependencies not listed in package.json: ' + grunt.log.wordlist(results, { color: 'red' }));
+        }
+      }
+
+      done();
+    });
+  });
+};


### PR DESCRIPTION
We have linting and checks for a lot of things, but if we miss including a dependency that we have installed locally then we will still have a crashing project.

Also: While JSHint checks for unused variables, this will now also check for unused modules which makes the cleanup of unused code go all the way to the top – yay!

All thanks to https://github.com/maxogden/dependency-check which will receive a PR to make this even better and which also will include the Grunt task from here.