### PR TITLE
updated husky to 0.7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
   },
   "peerDependencies": {
     "grunt": "~0.4.5",
-    "husky": "~0.6.1",
+    "husky": "~0.7.0",
     "istanbul": "~0.3.0",
     "mocha": ">=1.21.4-0 <3.0.0-0"
   },
   "devDependencies": {
     "chai": "^2.0.0",
     "grunt": "~0.4.5",
-    "husky": "~0.6.1",
+    "husky": "~0.7.0",
     "js-yaml": "^3.2.1",
     "mocha": ">=1.21.4-0 <3.0.0-0"
   }


### PR DESCRIPTION
Husky now supports node projects that are not in the same folder as the projects .git folder.